### PR TITLE
Updated SDWebImageDownloaderProgressBlock params

### DIFF
--- a/UIImageView+ProgressView.m
+++ b/UIImageView+ProgressView.m
@@ -77,7 +77,7 @@
     [self setImageWithURL:url
          placeholderImage:placeholder
                   options:options
-                 progress:^(NSUInteger receivedSize, long long expectedSize) {
+                 progress:^(NSInteger receivedSize, NSInteger expectedSize) {
                      CGFloat progress = ((CGFloat)receivedSize / (CGFloat)expectedSize);
                      [weakSelf updateProgress:progress];
                      if (progressBlock) {


### PR DESCRIPTION
This gave me trouble with Xcode 5.1. Updating both params to NSInteger fixed it, and it's in compliance with what the SDWebImageDownloaderProgressBlock uses
